### PR TITLE
Removed label from androidManifest

### DIFF
--- a/cappuccino/src/main/AndroidManifest.xml
+++ b/cappuccino/src/main/AndroidManifest.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.metova.cappuccino"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.metova.cappuccino">
 
     <application
         android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        tools:replace="android:label" />
+        android:supportsRtl="true" />
 
 </manifest>


### PR DESCRIPTION
Hello,

making a PR to remove the label as this can only introduce issues (androidmanifest merging is failing for me)
I don't see why a library needs a label
For reference, this is the AndroidManifest of Timber: 
https://github.com/JakeWharton/timber/blob/master/timber/src/main/AndroidManifest.xml

I would really appreciate if you could roll a new version with this to sort out me issue